### PR TITLE
:wrench: Update Play Services framework tag to work with phonegap-plugin-push

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,22 @@ This plugin is intended to be a dependency of other plugins.
 
 ## Dependents
 
-- [cordova-plugin-admob-free](https://www.npmjs.com/package/cordova-plugin-admob-free)
+* [cordova-plugin-admob-free](https://www.npmjs.com/package/cordova-plugin-admob-free)
 
 ## Disclaimer
 
-This is NOT an official Google product. It is just a community-driven project, repackaging SDKs for Cordova plugins.
+This is NOT an official Google product. It is just a community-driven project,
+repackaging SDKs for Cordova plugins.
+
+## Installation
+
+If you need to update the version of Play Services that is included by this
+plugin you can edit your config.xml file:
+
+```
+<plugin name="cordova-admob-sdk" spec="../plugins/cordova-admob-sdk">
+    <variable name="PLAY_SERVICES_VERSION" value="11.0.1" />
+</plugin>
+
+You just need to change the value to what your application needs. Note: This has been added for compatiblity with other plugins that include Play Services or FCM libraries.
+```

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,25 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    id="cordova-admob-sdk"
-    version="0.12.0">
-
+<plugin 
+    xmlns="http://apache.org/cordova/ns/plugins/1.0" 
+    xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-admob-sdk" version="0.12.0">
     <name>AdMob SDK</name>
     <description>Google AdMob SDK for Cordova</description>
     <author>Ratson</author>
     <keywords>admob,google,ad</keywords>
     <repo>https://github.com/rehy/cordova-admob-sdk.git</repo>
     <issue>https://github.com/rehy/cordova-admob-sdk/issues</issue>
-
     <engines>
         <engine name="cordova" version=">=3.0" />
+        <engine name="cordova-android" version=">=6.3.0"/>
     </engines>
-
     <platform name="android">
-        <framework src="com.google.android.gms:play-services-base:+" />
-        <framework src="com.google.android.gms:play-services-ads:+" />
+        <preference name="PLAY_SERVICES_VERSION" default="11.0.1"/>
+        <framework src="com.google.android.gms:play-services-base:$PLAY_SERVICES_VERSION" />
+        <framework src="com.google.android.gms:play-services-ads:$PLAY_SERVICES_VERSION" />
     </platform>
-
     <platform name="ios">
         <framework src="src/ios/GoogleMobileAds.framework" custom="true" />
         <framework src="AdSupport.framework" />
@@ -43,5 +40,4 @@
         <framework src="SystemConfiguration.framework" />
         <framework src="UIKit.framework" />
     </platform>
-
 </plugin>


### PR DESCRIPTION
This change works around an incompatibility with Play Services and phonegap-plugin-push. Folks can still over-ride the Play Services version using a preference/variable but if you leave it as + that causes issues with the Google Services Gradle Plugin.

Sorry about the formatting changes. A combination of Prettier, eslint, VS Code auto styling.